### PR TITLE
Fix type mismatches and missing fields in version 5.0

### DIFF
--- a/guitar_pro_5.ksy
+++ b/guitar_pro_5.ksy
@@ -46,11 +46,11 @@ seq:
   - id: track_count
     type: s4
   - id: measure_headers
-    type: measure_header(_index)
+    type: measure_header(_index.as<u4>)
     repeat: expr
     repeat-expr: measure_count
   - id: tracks
-    type: track(version.minor_version.to_i, _index)
+    type: track(version.minor_version.to_i.as<u4>, _index.as<u4>)
     repeat: expr
     repeat-expr: track_count
 # instances:
@@ -359,8 +359,10 @@ types:
         type: s1
         repeat: expr
         repeat-expr: 3
+        if: version_minor > 0
       - id: rse_gain
         type: s1
+        if: version_minor > 0
       - id: effect_name
         type: int_byte_str
         if: version_minor > 0


### PR DESCRIPTION
Hi, I was toying around with your gp5 file definition and I noticed a few small problems.
1. There are some integer type mismatches that may cause the generated code to fail to compile depending on the language you are using.
2. I am pretty sure that rse gain and eq are missing in version 5.0, at least they were not present in the file I have tested this with.